### PR TITLE
feat: impl HasRawWindowHandle for WindowResource

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -807,6 +807,7 @@ name = "pane"
 version = "0.2.1"
 dependencies = [
  "deno_core",
+ "raw-window-handle",
  "serde",
  "serde_millis",
  "winit",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ deno_core = "0.88.0"
 winit = { version = "0.25.0", features = ["serde"] }
 serde = { version = "1.0.125", features = ["derive"] }
 serde_millis = "0.1.1"
+raw-window-handle = "0.3.3"
 
 [features]
 default = ["init"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,9 @@ use winit::window::CursorIcon;
 use winit::window::Icon;
 use winit::window::Window;
 
+use raw_window_handle::HasRawWindowHandle;
+use raw_window_handle::RawWindowHandle;
+
 mod event;
 mod helpers;
 
@@ -161,6 +164,14 @@ impl WindowResource {
 impl Resource for WindowResource {
   fn name(&self) -> Cow<str> {
     "window".into()
+  }
+}
+
+// NOTE(leonski): we know this is safe as `Window` always has the
+// `raw_window_handle` function
+unsafe impl HasRawWindowHandle for WindowResource {
+  fn raw_window_handle(&self) -> RawWindowHandle {
+    self.0.raw_window_handle()
   }
 }
 


### PR DESCRIPTION
This makes it so that `WindowResource` implements `HasRawWindowHandle`, allowing [deno#10690](https://github.com/denoland/deno/pull/10690) to use the `WindowResource`. I also added a note above the `unsafe impl` for future reference.

Along with this, it would probably good to mention in the docs as it's useful for other plugins too.

https://github.com/denosaurs/pane/pull/1#issuecomment-845571812